### PR TITLE
Call `cancelAnimationFrame` on game end/crash

### DIFF
--- a/scripts/Globals.js
+++ b/scripts/Globals.js
@@ -897,7 +897,7 @@ Audio_WebAudio=1,
 	g_CurrentDepthIdStack =[],
 
 	g_gmlConst =null,
-	g_AudioBusMain = null;
+	g_AudioBusMain = null,
 	g_AudioMainVolumeNode =null,
 	g_WebAudioContext =null,
 	g_dialogs = null,
@@ -1030,6 +1030,7 @@ Audio_WebAudio=1,
 	c_greenA =  0,
 	c_blueA = 0,
     g_isZeus = 0,
+    g_requestAnimationID = 0,
     g_crcTable=[],
     g_CanvasName = 'canvas',
     g_Hex='0123456789ABCDEF';

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -1023,7 +1023,7 @@ function Audio_GetEngineState() {
 function Audio_WebAudioContextTryUnlock()
 {
 	if ( g_WaitingForWebAudioTouchUnlock )
-        return;
+		return;
 
 	g_WaitingForWebAudioTouchUnlock = true;
 
@@ -1035,7 +1035,7 @@ function Audio_WebAudioContextTryUnlock()
 		eventTypeStart = "touchstart";
 		eventTypeEnd = "touchend";
 	}
-    if ((window.PointerEvent) || (window.navigator.pointerEnabled)||(window.navigator.msPointerEnabled)) {
+    if ((window.PointerEvent) || (window.navigator.pointerEnabled) || (window.navigator.msPointerEnabled)) {
 		eventTypeStart = "pointerdown";
 		eventTypeEnd = "pointerup";
     } // end if
@@ -1044,6 +1044,10 @@ function Audio_WebAudioContextTryUnlock()
 	// Set up context unlock events
 	var unlockWebAudioContext = function ()
 	{
+		if ( !Audio_ContextExists() )
+			// This case should only happen if the game ends or crashes before attempting to unlock the AudioContext instance.
+			// However, let's not make assumptions and keep the event listeners active.
+			return;
 		g_WebAudioContext.resume().then( function ()
 		{
 			document.body.removeEventListener( eventTypeStart, unlockWebAudioContext );


### PR DESCRIPTION
- Fixed the case where any error occurring before the game reached its final state would prevent the initialisation from proceeding to the next step (`g_StartUpState` variable). Consequently, the same error-inducing code would execute at each `requestAnimationFrame` call.

Basically, a code snippet like this in a Create Event in the first room of the game would show the message endlessly:
```javascript
show_message("test");
var a = "c";
var b = a + 1; // error
```
This is likely related to https://github.com/YoYoGames/GameMaker-Bugs/issues/4726, but I'm attaching another sample [here](https://github.com/user-attachments/files/15687178/sample.zip).

- The previous change also fixed the very unlikely case where managing to call `game_restart`, `room_goto` or similar after a game end/crash would work.

These changes only work on browsers that support `requestAnimation` / `cancelAnimationFrame`, which should be fine since the browser vendors implemented these features more than a decade ago. The only affected browser is Opera Mini but I'm not sure GameMaker would run on it at all since it lacks so many features.