### PR TITLE
Make `sequence_instance` hold `undefined` instead of `null` when the instance is not being controlled by a sequence

### DIFF
--- a/scripts/yyInstance.js
+++ b/scripts/yyInstance.js
@@ -124,7 +124,7 @@ function    yyInstance( _xx, _yy, _id, _objectind, _AddObjectLink, _create_dummy
 	this.fOutsideRoom = false;
 	this.fInSequence = false;
 	this.fOwnedBySequence = false;
-	this.m_pControllingSeqInst = null;
+	this.m_pControllingSeqInst = undefined;
 	this.fControlledBySequence = false;
 	this.fDrawnBySequence = true;
 

--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -6681,7 +6681,7 @@ CSequenceInstance.prototype.CleanupInstances = function ()
 				{
                     pInst.SetInSequence(false);
                     pInst.SetControlledBySequence(false);
-                    pInst.SetControllingSeqInst(null);
+                    pInst.SetControllingSeqInst(undefined);
 
                     if (pInstInfo.ownedBySequence == true)
                     {
@@ -6753,7 +6753,7 @@ CSequenceInstance.prototype.SetInstanceInSequenceStatus = function (_inSequence)
                     }
                     else
                     {
-                        pInst.SetControllingSeqInst(null);
+                        pInst.SetControllingSeqInst(undefined);
                     }                    
 				}
 			}


### PR DESCRIPTION
As per https://github.com/YoYoGames/GameMaker-Bugs/issues/1873#issuecomment-2132061206 (+ https://manual.gamemaker.io/lts/en/GameMaker_Language/GML_Reference/Asset_Management/Sequences/sequence_instance.htm).