### PR TITLE
Detect ref, null and unknown types in `YYTypeof`

### DIFF
--- a/scripts/functions/Function_Maths.js
+++ b/scripts/functions/Function_Maths.js
@@ -1349,12 +1349,23 @@ function YYInstanceof(_x) {
 function YYTypeof(_x) {
     var ret = typeof(_x);
     switch (ret) {
-        case "boolean": return "bool";
-        case "function": return "method";
+        case "number":
+        case "string":
+        case "undefined":
+            return ret;
+        case "boolean":
+            return "bool";
+        case "function":
+            return "method";
         case "object":
-            // JS objects that aren't arrays count as pointers
-            return (_x instanceof Array) ? "array" : (_x instanceof ArrayBuffer) ? "ptr" : (_x instanceof Long) ? "int64" : "struct";
-        default: return ret;
+            if (_x === null) return "null"; // `typeof null` is "object" in JS
+            if (_x instanceof Array) return "array";
+            if (_x instanceof ArrayBuffer) return "ptr";
+            if (_x instanceof Long) return "int64";
+            if (_x instanceof YYRef) return "ref";
+            return "struct";
+        default:
+            return "unknown"; // this would be a "symbol" or a "bigint" which are not supported types in GameMaker
     }
 }
 


### PR DESCRIPTION
Related to [#4611](https://github.com/YoYoGames/GameMaker-Bugs/issues/4611), `object_index` was already working as intended, but `typeof(object_index)` was incorrectly returning "struct". This now returns "ref".

While I was at it, I also added the cases for "null" and "unknown" (actually those that GameMaker wouldn't support) types.


----------

Unrelated bug for future fix:
"caught a massive optimization problem in HTML5, where every time you move an object to a different depth, it grows an array, and the array doesn't shrink back down again, so now you have an O(n) performance problem where n is how many times you've moved depths"
"and the reason the array doesn't shrink back down again is specifically an optimization decision they made which is meant to avoid reallocating memory
BUT, array memory allocation in JS doesn't work quite in that way, because JS itself has its own optimizations for array allocation under the hood, so that optimization was self-defeating"
(note: GMS 1 is not affected)
Likely regressed by https://github.com/YoYoGames/GameMaker-HTML5/commit/0f4f72caa47d0d61b274afb57f78d6a92321baad